### PR TITLE
Fix for niels-nijens/Logging#3, with tests

### DIFF
--- a/src/Adapters/AbstractLogAdapter.php
+++ b/src/Adapters/AbstractLogAdapter.php
@@ -176,12 +176,12 @@ abstract class AbstractLogAdapter implements LogAdapterInterface
      **/
     protected function isLoggingForChannelAndLogLevel($level, array $context)
     {
-        $isLogging = true;
-        if (!in_array($level, Logger::getLogLevels($this->getConfigurationValue("level") ) ) ) {
-            $isLogging = false;
+        $isLevel = $isLogging = false;
+        if (in_array($level, Logger::getLogLevels($this->getConfigurationValue("level") ) ) ) {
+            $isLevel = true;
         }
 
-        if ($isLogging === true && (!array_key_exists("channel", $context) || count($this->getChannels() ) === 0 || in_array($context["channel"], $this->getChannels() ) ) ) {
+        if ($isLevel === true && (!array_key_exists("channel", $context) || count($this->getChannels() ) === 0 || in_array($context["channel"], $this->getChannels() ) ) ) {
             $isLogging = true;
         }
 

--- a/tests/Adapters/AbstractLogAdapterTest.php
+++ b/tests/Adapters/AbstractLogAdapterTest.php
@@ -104,6 +104,8 @@ abstract class AbstractLogAdapterTest extends \PHPUnit_Framework_TestCase
             array(LogLevel::NOTICE, array(), array("foo"), array(), true),
             array(LogLevel::NOTICE, array("channel" => "foo"), array("foo"), array(), true),
             array(LogLevel::NOTICE, array("channel" => "foo"), array(), array(), true),
+            array(LogLevel::NOTICE, array("channel" => "foo"), array("bar"), array(), false),
+            array(LogLevel::NOTICE, array("channel" => "foo"), array("bar", "foo"), array(), true),
             array(LogLevel::INFO, array(), array(), array("level" => LogLevel::INFO), true),
             array(LogLevel::INFO, array(), array(), array("level" => LogLevel::NOTICE), false),
             array(LogLevel::INFO, array("channel" => "foo"), array("foo"), array("level" => LogLevel::INFO), true),


### PR DESCRIPTION
When an adapter is configured for a specific channel, it shouldn't log messages
sent to a different channel.
